### PR TITLE
Add confirmation prompt for task deletion (fixed)

### DIFF
--- a/js/tasks.js
+++ b/js/tasks.js
@@ -213,6 +213,11 @@ function toggleTaskCompletion(event, isDone) {
 
 // delete task
 function deleteTask(event) {
+  // delete confirmation
+  const deleteConfirmation = confirm("Realmente deseja excluir essa tarefa?");
+  if (!deleteConfirmation) return;
+
+  // delete Action
   const taskToDeleteId = event.target.parentNode.parentNode.id;
   const taskToDelete = document.getElementById(taskToDeleteId);
 


### PR DESCRIPTION
Add a new feature in the development branch that includes a confirmation prompt for deleting a specific task from the ToDo list. This feature ensures that the user is prompted to confirm their intention to delete the task before it is permanently removed from the list.